### PR TITLE
Adding in exit code for when script times out as it was passing before

### DIFF
--- a/bin/hive-batch-poll
+++ b/bin/hive-batch-poll
@@ -128,15 +128,13 @@ p curl_line
 }
 script_time=Time.now-t1
 puts "Script took #{script_time} seconds"
+puts "View results: #{batch_url}"
 
 
 if script_time>=timeout.to_i
-  puts "ERROR: Job timed out! View results: #{batch_url}"
-  exit(1)
+  abort "ERROR: Job timed out! View results: #{batch_url}"
 else
-  puts "View results: #{batch_url}"
-  puts "Some unknown error occured, failing"
-  exit(1)
+  abort "Some unknown error occured, failing"
 end
 
 

--- a/bin/hive-batch-poll
+++ b/bin/hive-batch-poll
@@ -126,7 +126,11 @@ p curl_line
       sleep 10
     end
 }
+script_time=Time.now-t1
 
-puts "Script took #{Time.now-t1} seconds"
-puts "View results: #{batch_url}"
-exit(1)
+if timeout.to_i >=script_time
+  puts "ERROR: Job timed out! View results: #{batch_url}"
+  puts "Script took #{script_time} seconds"
+  exit(1)
+end
+

--- a/bin/hive-batch-poll
+++ b/bin/hive-batch-poll
@@ -127,10 +127,17 @@ p curl_line
     end
 }
 script_time=Time.now-t1
+puts "Script took #{script_time} seconds"
 
-if timeout.to_i >=script_time
+
+if script_time>=timeout.to_i
   puts "ERROR: Job timed out! View results: #{batch_url}"
-  puts "Script took #{script_time} seconds"
+  exit(1)
+else
+  puts "View results: #{batch_url}"
+  puts "Some unknown error occured, failing"
   exit(1)
 end
+
+
 


### PR DESCRIPTION
hive jenkins trigger uses the exit code to see if the script failed or passed. 
But when it was timing out the exit code was success so now exiting correctly. 